### PR TITLE
Don't assume sudo is installed as an rpm package

### DIFF
--- a/lib/facter/sudoversion.rb
+++ b/lib/facter/sudoversion.rb
@@ -1,9 +1,7 @@
 require 'puppet'
 Facter.add("sudoversion") do
   setcode do
-    if Facter::Util::Resolution.which('rpm')
-      sudoversion = Facter::Util::Resolution.exec('rpm -q sudo --qf \'%{VERSION}\'')
-    elsif Facter::Util::Resolution.which('sudo') and Facter::Util::Resolution.which('awk')
+    if Facter::Util::Resolution.which('sudo') and Facter::Util::Resolution.which('awk')
       sudoversion = Facter::Util::Resolution.exec('sudo -V | awk \'/Sudo version/ {print $3}\'')
     end
   end


### PR DESCRIPTION
This breaks on at least AIX where sudo simply part of the base image but 'rpm' still exists as a command.
